### PR TITLE
Auto-advance returning users to spending input

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
     <!-- Returning User Banner (hidden by default) -->
     <div id="returningBanner" class="returning-banner" style="display: none;">
-      <span>Welcome back! Using your saved income.</span>
+      <span>Welcome back! Using your saved income. Enter a spending amount below.</span>
       <button type="button" onclick="app.clearAndReset()">Start fresh</button>
     </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -50,6 +50,9 @@ const app = {
 
     // Show tax result and enable continue
     this.updateTaxDisplay();
+
+    // Auto-advance to Stage 2 so returning users can immediately enter spending
+    this.showStage(2);
   },
 
   // Set input mode (income or direct tax)


### PR DESCRIPTION
## Summary
- Auto-advance returning users to Stage 2 (spending input) so they can immediately enter expenditures without clicking Continue
- Updated the returning user banner message to guide users: "Enter a spending amount below"
- Income is already saved to localStorage; this change improves the UX for returning users

## Test plan
- [ ] Visit the page for the first time and enter an income amount
- [ ] Reload the page and verify Stage 2 is automatically visible
- [ ] Verify the banner shows "Welcome back! Using your saved income. Enter a spending amount below."
- [ ] Verify saved income is restored and user can immediately enter spending

🤖 Generated with [Claude Code](https://claude.com/claude-code)