### PR TITLE
Improve monthly data verification workflow reliability

### DIFF
--- a/.github/workflows/monthly-data-verification.yml
+++ b/.github/workflows/monthly-data-verification.yml
@@ -87,7 +87,7 @@ jobs:
               --output-format stream-json \
               --model opus \
               --dangerously-skip-permissions \
-              --max-turns 300 \
+              --max-turns 600 \
               "You are a DATA ACCURACY VERIFICATION agent for the ${REPO} repository.
 
             This is a monthly automated check to ensure all data in the repository is still accurate
@@ -170,7 +170,7 @@ jobs:
             - Prefer authoritative sources (official docs, pricing pages) over third-party sites
             - If a data point cannot be verified (no reliable source found), note this but don't change it
 
-            Start by exploring the repository structure to understand what data exists." < /dev/null 2>&1 | tee /workspaces/how-much-did-it-cost-me/verification-output.jsonl
+            Start by exploring the repository structure to understand what data exists." < /dev/null 2>&1 | tee ./verification-output.jsonl
 
       - name: Upload verification output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Double max-turns from 300 to 600 to give Claude more capacity for thorough data verification
- Fix output path bug that referenced wrong repository directory

## Test plan
- [ ] Manually trigger the workflow via workflow_dispatch to verify it runs successfully
- [ ] Confirm the verification-output.jsonl artifact is uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)