### PR TITLE
Add realistic federal spending options and billions input

### DIFF
--- a/.github/workflows/monthly-data-verification.yml
+++ b/.github/workflows/monthly-data-verification.yml
@@ -113,6 +113,19 @@ jobs:
                - Feature availability or limitations
                - Any numerical data that comes from external sources
 
+               **IMPORTANT - Notable Federal Spending Items**: The file js/data.js contains a
+               NOTABLE_SPENDING object with specific federal spending figures that MUST be verified:
+               - Gerald R. Ford Aircraft Carrier (CVN-78) program cost
+               - ACA Premium Subsidies for the most recent fiscal year (update year label if needed)
+               - Infrastructure Investment and Jobs Act spending
+               - James Webb Space Telescope total development cost
+
+               For each notable spending item, verify:
+               - The dollar amount is still accurate
+               - The source attribution is correct
+               - The notes/description remain accurate
+               - Update the lastVerified date when confirming accuracy
+
             3. **WEB SEARCH VERIFICATION**: Use your web search capabilities to verify each
                identifiable claim against current information. Search for:
                - Official documentation or pricing pages

--- a/css/styles.css
+++ b/css/styles.css
@@ -140,6 +140,41 @@ header p {
   border-color: var(--color-primary);
 }
 
+.input-wrapper-billions {
+  position: relative;
+}
+
+.input-wrapper-billions input {
+  padding-right: 5rem;
+}
+
+.input-wrapper .suffix {
+  position: absolute;
+  right: 1rem;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+.input-unit {
+  font-weight: 400;
+  color: var(--color-primary);
+  font-size: 0.85rem;
+}
+
+.input-hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin-top: 0.5rem;
+  min-height: 1.2rem;
+}
+
+.input-hint strong {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
 /* Toggle Buttons (Filing Status, Input Mode) */
 .toggle-group {
   display: flex;
@@ -210,6 +245,16 @@ header p {
 .chip:hover {
   background: rgba(37, 99, 235, 0.1);
   border-color: var(--color-primary);
+}
+
+.chip-notable {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: var(--color-primary);
+  font-weight: 500;
+}
+
+.chip-notable:hover {
+  background: rgba(37, 99, 235, 0.15);
 }
 
 /* Category Selector */

--- a/index.html
+++ b/index.html
@@ -79,20 +79,18 @@
       </p>
 
       <div class="input-group">
-        <label for="spending">Spending Amount</label>
-        <div class="input-wrapper">
+        <label for="spending">Spending Amount <span class="input-unit">(in billions)</span></label>
+        <div class="input-wrapper input-wrapper-billions">
           <span class="prefix">$</span>
-          <input type="text" id="spending" inputmode="numeric" placeholder="1,000,000,000"
+          <input type="text" id="spending" inputmode="decimal" placeholder="10"
                  oninput="app.handleSpendingInput(this.value)">
+          <span class="suffix">billion</span>
         </div>
+        <div class="input-hint" id="spendingHint"></div>
       </div>
 
-      <div class="example-chips" aria-label="Example amounts">
-        <button type="button" class="chip" onclick="app.setSpending(1000000)">$1 million</button>
-        <button type="button" class="chip" onclick="app.setSpending(100000000)">$100 million</button>
-        <button type="button" class="chip" onclick="app.setSpending(1000000000)">$1 billion</button>
-        <button type="button" class="chip" onclick="app.setSpending(10000000000)">$10 billion</button>
-        <button type="button" class="chip" onclick="app.setSpending(100000000000)">$100 billion</button>
+      <div id="spendingChips" class="example-chips" aria-label="Example amounts">
+        <!-- Chips rendered dynamically from EXAMPLE_AMOUNTS in data.js -->
       </div>
 
       <button type="button" id="continueToStage3" class="continue-btn" disabled onclick="app.showStage(3)">

--- a/js/data.js
+++ b/js/data.js
@@ -125,11 +125,52 @@ const COMPARISONS = [
   { max: Infinity, text: 'About {days} days of your annual tax contribution' }
 ];
 
+// Notable Federal Spending Items
+// These are specific, verifiable spending figures for "fun" comparisons
+// Sources should be verified monthly by the data verification workflow
+const NOTABLE_SPENDING = {
+  geraldRFordCarrier: {
+    label: 'Gerald R. Ford Aircraft Carrier',
+    value: 13_300_000_000,           // $13.3 billion (USS Gerald R. Ford total program cost)
+    source: 'Congressional Research Service',
+    lastVerified: DATA_LAST_UPDATED,
+    category: 'defense',
+    notes: 'Total acquisition cost for lead ship CVN-78'
+  },
+  acaSubsidies: {
+    label: 'ACA Premium Subsidies (2024)',
+    value: 82_000_000_000,           // $82 billion (FY2024 premium tax credits)
+    source: 'Congressional Budget Office',
+    lastVerified: DATA_LAST_UPDATED,
+    category: 'medicare',
+    notes: 'Premium tax credits and cost-sharing reductions'
+  },
+  infrastructureBill: {
+    label: 'Infrastructure Investment Act',
+    value: 550_000_000_000,          // $550 billion (new spending over 5 years)
+    source: 'White House Fact Sheet',
+    lastVerified: DATA_LAST_UPDATED,
+    category: 'general',
+    notes: 'New federal investment portion of the $1.2T bill'
+  },
+  jamesWebbTelescope: {
+    label: 'James Webb Space Telescope',
+    value: 10_000_000_000,           // $10 billion (total development cost)
+    source: 'NASA',
+    lastVerified: DATA_LAST_UPDATED,
+    category: 'general',
+    notes: 'Total lifecycle development cost'
+  }
+};
+
 // Example spending amounts for the chips
 const EXAMPLE_AMOUNTS = [
-  { label: '$1 million', value: 1_000_000 },
-  { label: '$100 million', value: 100_000_000 },
   { label: '$1 billion', value: 1_000_000_000 },
   { label: '$10 billion', value: 10_000_000_000 },
-  { label: '$100 billion', value: 100_000_000_000 }
+  { label: '$100 billion', value: 100_000_000_000 },
+  { label: '$1 trillion', value: 1_000_000_000_000 },
+  { label: NOTABLE_SPENDING.jamesWebbTelescope.label, value: NOTABLE_SPENDING.jamesWebbTelescope.value, category: NOTABLE_SPENDING.jamesWebbTelescope.category },
+  { label: NOTABLE_SPENDING.geraldRFordCarrier.label, value: NOTABLE_SPENDING.geraldRFordCarrier.value, category: NOTABLE_SPENDING.geraldRFordCarrier.category },
+  { label: NOTABLE_SPENDING.acaSubsidies.label, value: NOTABLE_SPENDING.acaSubsidies.value, category: NOTABLE_SPENDING.acaSubsidies.category },
+  { label: NOTABLE_SPENDING.infrastructureBill.label, value: NOTABLE_SPENDING.infrastructureBill.value, category: NOTABLE_SPENDING.infrastructureBill.category }
 ];


### PR DESCRIPTION
## Summary

- **Add notable federal spending items** with verified dollar figures that users can select as quick examples
- **Change spending input to billions** - users now type "10" to mean $10 billion, with clear labeling and hint showing full amount
- **Update monthly verification workflow** to keep the notable spending figures accurate

## Notable Spending Items Added

| Item | Amount | Category |
|------|--------|----------|
| Gerald R. Ford Aircraft Carrier (CVN-78) | $13.3 billion | Defense |
| ACA Premium Subsidies (2024) | $82 billion | Medicare/Medicaid |
| Infrastructure Investment Act | $550 billion | General Government |
| James Webb Space Telescope | $10 billion | General Government |

## Spending Input Changes

- Removed $1 million and $100 million options (not realistic federal spending)
- Added $1 trillion option
- Input now expects billions: type "10" → shows "= **$10.0 billion**"
- Label clearly shows "(in billions)" with "billion" suffix in input field
- Notable items auto-select their correct funding category when clicked

## Test plan

- [ ] Verify spending chips render correctly (4 basic amounts + 4 notable items)
- [ ] Type a number in spending input and verify hint shows full amount
- [ ] Click a notable spending chip and verify it auto-selects the correct category
- [ ] Test "Try Another Amount" clears the input and hint
- [ ] Test "Start Over" resets everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)