### PR TITLE
Add detailed program examples to funding category buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,31 +110,31 @@
       <div class="category-grid" role="group" aria-label="Funding category">
         <button type="button" class="category-btn" data-category="defense" onclick="app.selectCategory('defense')">
           <span class="name">Defense & Military</span>
-          <span class="examples">Pentagon, weapons systems, VA</span>
+          <span class="examples">Pentagon, weapons systems, military bases, VA healthcare & benefits</span>
           <span class="tax-source">Funded by: Income Tax</span>
         </button>
 
         <button type="button" class="category-btn" data-category="general" onclick="app.selectCategory('general')">
           <span class="name">General Government</span>
-          <span class="examples">Agencies, transportation, education, research</span>
+          <span class="examples">SNAP, WIC, TANF, child care (CCAP/CCDBG), education grants, housing assistance, transportation, federal agencies, research</span>
           <span class="tax-source">Funded by: Income Tax</span>
         </button>
 
         <button type="button" class="category-btn" data-category="socialSecurity" onclick="app.selectCategory('socialSecurity')">
           <span class="name">Social Security</span>
-          <span class="examples">SS benefits, SS administration</span>
+          <span class="examples">Retirement benefits, disability (SSDI), survivors benefits</span>
           <span class="tax-source">Funded by: Payroll Tax (FICA)</span>
         </button>
 
         <button type="button" class="category-btn" data-category="medicare" onclick="app.selectCategory('medicare')">
           <span class="name">Medicare & Medicaid</span>
-          <span class="examples">Healthcare programs</span>
+          <span class="examples">Medicare, Medicaid, CHIP, ACA marketplace subsidies</span>
           <span class="tax-source">Funded by: Mixed (Income + FICA)</span>
         </button>
 
         <button type="button" class="category-btn" data-category="interest" onclick="app.selectCategory('interest')">
           <span class="name">Interest on Debt</span>
-          <span class="examples">Debt payments to bondholders</span>
+          <span class="examples">Treasury bond payments, debt service</span>
           <span class="tax-source">Funded by: Income Tax</span>
         </button>
       </div>

--- a/js/data.js
+++ b/js/data.js
@@ -73,28 +73,28 @@ const FEDERAL_BUDGET = {
 const FUNDING_CATEGORIES = {
   defense: {
     name: 'Defense & Military',
-    examples: 'Pentagon, weapons systems, VA',
+    examples: 'Pentagon, weapons systems, military bases, VA healthcare & benefits',
     taxSource: 'income',
     budgetPool: FEDERAL_BUDGET.spending.defense,
     revenuePool: FEDERAL_BUDGET.revenue.individualIncomeTax
   },
   general: {
     name: 'General Government',
-    examples: 'Agencies, transportation, education, research',
+    examples: 'SNAP, WIC, TANF, child care (CCAP/CCDBG), education grants, housing assistance, transportation, federal agencies, research',
     taxSource: 'income',
     budgetPool: FEDERAL_BUDGET.spending.otherDiscretionary + FEDERAL_BUDGET.spending.otherMandatory,
     revenuePool: FEDERAL_BUDGET.revenue.individualIncomeTax
   },
   socialSecurity: {
     name: 'Social Security',
-    examples: 'SS benefits, SS administration',
+    examples: 'Retirement benefits, disability (SSDI), survivors benefits',
     taxSource: 'fica',
     budgetPool: FEDERAL_BUDGET.spending.socialSecurity,
     revenuePool: FEDERAL_BUDGET.revenue.payrollTax
   },
   medicare: {
     name: 'Medicare & Medicaid',
-    examples: 'Healthcare programs',
+    examples: 'Medicare, Medicaid, CHIP, ACA marketplace subsidies',
     taxSource: 'mixed',
     budgetPool: FEDERAL_BUDGET.spending.medicareMedicaid,
     // Mixed: ~60% from general funds, ~40% from payroll
@@ -104,7 +104,7 @@ const FUNDING_CATEGORIES = {
   },
   interest: {
     name: 'Interest on Debt',
-    examples: 'Debt payments to bondholders',
+    examples: 'Treasury bond payments, debt service',
     taxSource: 'income',
     budgetPool: FEDERAL_BUDGET.spending.netInterest,
     revenuePool: FEDERAL_BUDGET.revenue.individualIncomeTax


### PR DESCRIPTION
## Summary
- Expands the example programs listed in each funding category to help users quickly identify the correct category for their program
- Adds specific program names like SNAP, WIC, TANF, CCAP/CCDBG, CHIP, SSDI to make selection easier
- Addresses the use case of finding state-administered programs like Minnesota's CCAP (Child Care Assistance Program)

## Test plan
- [ ] Verify all 5 funding category buttons display updated example text
- [ ] Confirm "child care (CCAP/CCDBG)" appears in General Government category
- [ ] Test that clicking categories still works correctly and shows results

🤖 Generated with [Claude Code](https://claude.com/claude-code)