### PR TITLE
Fix claude-code-action parameter name in PR reviews workflow

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -58,7 +58,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          prompt: |
             You are an "Impatient User" reviewer testing the "How Much Did It Cost Me?" web application.
             The app is running at http://localhost:8080
 
@@ -117,8 +117,6 @@ jobs:
             6. **Screenshots**: Include relevant screenshots from your Playwright session
 
             Begin your testing now using the playwright-skill.
-          allowed_tools: "Bash,Read,Glob,Grep,WebFetch,mcp__playwright__*"
-          timeout_minutes: 15
 
   # Gate job - ensures all agent reviews pass before merge
   all-agent-reviews-passed:


### PR DESCRIPTION
## Summary
- Changes `direct_prompt` to `prompt` - the correct parameter name for `anthropics/claude-code-action@v1`
- Removes invalid parameters `allowed_tools` and `timeout_minutes` that were being ignored

## Problem
The PR Reviews workflow was using incorrect parameter names, causing Claude to run without receiving the review prompt. The workflow logs showed:

```
##[warning]Unexpected input(s) 'direct_prompt', 'allowed_tools', 'timeout_minutes', valid inputs are ['trigger_phrase', 'assignee_trigger', 'label_trigger', ... 'prompt', ...]
```

This resulted in the "Impatient User Review" job completing successfully but not actually running any tests or leaving any PR comments.

## Test plan
- [ ] Verify this PR triggers the PR Reviews workflow
- [ ] Check that the workflow runs without the "Unexpected input" warning
- [ ] Confirm Claude leaves a review comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)