### PR TITLE
Fix spending chips appearing pre-selected and add selection highlight

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -247,14 +247,10 @@ header p {
   border-color: var(--color-primary);
 }
 
-.chip-notable {
-  background: rgba(37, 99, 235, 0.08);
+.chip.selected {
+  background: rgba(37, 99, 235, 0.1);
   border-color: var(--color-primary);
-  font-weight: 500;
-}
-
-.chip-notable:hover {
-  background: rgba(37, 99, 235, 0.15);
+  color: var(--color-primary);
 }
 
 /* Category Selector */

--- a/js/app.js
+++ b/js/app.js
@@ -198,6 +198,9 @@ const app = {
 
     // Enable continue if valid
     document.getElementById('continueToStage3').disabled = billions <= 0;
+
+    // Clear chip selection when user types custom value
+    this.clearChipSelection();
   },
 
   // Set spending from chip (optionally auto-select category for notable items)
@@ -227,17 +230,36 @@ const app = {
     if (!container) return;
 
     container.innerHTML = '';
-    EXAMPLE_AMOUNTS.forEach(item => {
+    EXAMPLE_AMOUNTS.forEach((item, index) => {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'chip';
-      if (item.category) {
-        btn.classList.add('chip-notable');
-      }
+      btn.dataset.index = index;
+      btn.dataset.value = item.value;
       btn.textContent = item.label;
-      btn.onclick = () => this.setSpending(item.value, item.category || null);
+      btn.onclick = () => this.selectChip(index, item.value, item.category || null);
       container.appendChild(btn);
     });
+  },
+
+  // Select a chip and highlight it
+  selectChip(index, amount, category) {
+    // Update visual selection
+    document.querySelectorAll('#spendingChips .chip').forEach(chip => {
+      chip.classList.toggle('selected', chip.dataset.index === String(index));
+    });
+    this.state.selectedChipIndex = index;
+
+    // Set the spending amount
+    this.setSpending(amount, category);
+  },
+
+  // Clear chip selection (when user types custom value)
+  clearChipSelection() {
+    document.querySelectorAll('#spendingChips .chip').forEach(chip => {
+      chip.classList.remove('selected');
+    });
+    this.state.selectedChipIndex = null;
   },
 
   // Select funding category


### PR DESCRIPTION
## Summary
- Removed blue "notable" styling from spending example chips that made them look pre-selected
- Added selection highlight so clicked chips show blue styling to indicate they're selected
- Selection clears when user types a custom value in the input field

## Test plan
- [ ] Visit the spending input stage and verify no chips appear blue/selected initially
- [ ] Click a spending chip and verify it gets highlighted with blue styling
- [ ] Click a different chip and verify the highlight moves to the new selection
- [ ] Type a custom value in the input and verify chip selection clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)