### PR TITLE
Fix Privacy & Security link to use GitHub rendered markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
       <p>Based on FY 2024 federal budget data from CBO and IRS.</p>
       <p>For educational purposes only. Consult a tax professional for your specific situation.</p>
       <p class="footer-links">
-        <a href="PRIVACY.md" target="_blank">Privacy & Security</a> &middot;
+        <a href="https://github.com/NickBorgers/how-much-did-it-cost-me/blob/main/PRIVACY.md" target="_blank" rel="noopener">Privacy & Security</a> &middot;
         <a href="https://github.com/NickBorgers/how-much-did-it-cost-me" target="_blank" rel="noopener">View Source on GitHub</a>
       </p>
     </footer>


### PR DESCRIPTION
## Summary
- Changed the Privacy & Security footer link from pointing to raw `PRIVACY.md` to the GitHub blob URL
- Users now see properly rendered markdown instead of plaintext when clicking the link

## Test plan
- [ ] Click the Privacy & Security link in the footer
- [ ] Verify it opens the GitHub-rendered PRIVACY.md page (not raw markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)