### PR TITLE
Fix income recalculation when changed after viewing results

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -142,6 +142,7 @@ const app = {
     this.state.ficaTax = fica.total;
 
     this.updateTaxDisplay();
+    this.recalculateResultsIfNeeded();
     this.saveState();
   },
 
@@ -154,6 +155,7 @@ const app = {
     this.state.ficaTax = fica.total;
 
     this.updateTaxDisplay();
+    this.recalculateResultsIfNeeded();
   },
 
   // Update the tax display
@@ -176,6 +178,18 @@ const app = {
     } else {
       taxResultEl.style.display = 'none';
       continueBtn.disabled = true;
+    }
+  },
+
+  // Recalculate results if user has already progressed to Stage 4
+  recalculateResultsIfNeeded() {
+    const stage4 = document.getElementById('stage4');
+
+    // Only recalculate if results are currently visible and we have all necessary data
+    if (stage4.classList.contains('visible') &&
+        this.state.spendingAmount > 0 &&
+        this.state.category) {
+      this.calculateAndShowResults();
     }
   },
 


### PR DESCRIPTION
## Summary

Fixes a bug where manually changing income after selecting a spending item and viewing results did not update the displayed calculations.

## Problem

If a user:
1. Entered an income (e.g., $100,000)
2. Selected a spending item  
3. Selected a category and viewed results
4. Scrolled back to Stage 1 and changed their income (e.g., to $150,000)

The results would remain stale and not reflect the new income.

## Solution

Added a `recalculateResultsIfNeeded()` helper function that:
- Checks if results (Stage 4) are currently visible
- Checks if spending amount and category are set
- Automatically recalculates and updates results when income changes

This helper is called from:
- `recalculateTax()` - when using income input mode
- `handleDirectTaxInput()` - when using direct tax input mode

## Test Results

Playwright test confirms the fix works correctly:
- Initial share with $100k income: $57.67
- Updated share with $150k income: $106  
- Results update automatically without user intervention

## Files Changed

- `js/app.js`: Added `recalculateResultsIfNeeded()` method and integrated it into tax calculation flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)