### PR TITLE
Add support for savings items in trending spending

### DIFF
--- a/.github/workflows/weekly-trending-spending.yml
+++ b/.github/workflows/weekly-trending-spending.yml
@@ -142,7 +142,8 @@ jobs:
                    source: '[Where the number comes from]',
                    lastVerified: '[today's date YYYY-MM-DD]',
                    category: '[one of: defense, general, medicare, socialSecurity, interest]',
-                   notes: '[Brief context - why this is in the news, accuracy note if disputed]'
+                   notes: '[Brief context - why this is in the news, accuracy note if disputed]',
+                   isSavings: [true if this is a SAVINGS/reduction claim, omit or false for spending]
                  },
                  trending2: { ... },
                  trending3: { ... },
@@ -160,6 +161,13 @@ jobs:
                - We don't care if it's perfectly accurate - the point is to show what the
                  headline number would mean to an individual taxpayer
 
+               SAVINGS vs SPENDING:
+               - If an item represents CLAIMED SAVINGS (like DOGE efficiency claims, program
+                 cuts, or cost reductions), add 'isSavings: true' to that item
+               - Savings items are displayed with a different style (green) to distinguish
+                 them from regular spending
+               - Most items will NOT have isSavings - only add it for actual savings/reductions
+
             5. **CREATE A PR**: After updating the file:
                a. Create a new branch: git checkout -b trending-spending/weekly-\$(date +%Y-%m-%d)
                b. Commit the changes: git commit with descriptive message
@@ -173,15 +181,15 @@ jobs:
 
             ### This Week's Trending Items
 
-            | Item | Amount | Category | Why It's Trending |
-            |------|--------|----------|-------------------|
-            | [Item 1] | $X billion | [category] | [brief explanation] |
-            | [Item 2] | $X billion | [category] | [brief explanation] |
-            | [Item 3] | $X billion | [category] | [brief explanation] |
-            | [Item 4] | $X billion | [category] | [brief explanation] |
-            | [Item 5] | $X billion | [category] | [brief explanation] |
-            | [Item 6] | $X billion | [category] | [brief explanation] |
-            | [Item 7] | $X billion | [category] | [brief explanation] |
+            | Item | Amount | Category | Type | Why It's Trending |
+            |------|--------|----------|------|-------------------|
+            | [Item 1] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 2] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 3] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 4] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 5] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 6] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
+            | [Item 7] | $X billion | [category] | [Spending/Savings] | [brief explanation] |
 
             ### Permanent Items (unchanged)
             - James Webb Space Telescope (\$10 billion)

--- a/css/styles.css
+++ b/css/styles.css
@@ -253,6 +253,23 @@ header p {
   color: var(--color-primary);
 }
 
+.chip.savings {
+  background: rgba(5, 150, 105, 0.1);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.chip.savings:hover {
+  background: rgba(5, 150, 105, 0.15);
+  border-color: var(--color-success);
+}
+
+.chip.savings.selected {
+  background: rgba(5, 150, 105, 0.2);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
 /* Category Selector */
 .category-grid {
   display: grid;

--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,8 @@ const app = {
     directTax: null, // null means calculated, number means user-entered
     spendingAmount: 0,
     category: null,
-    isMultiYear: false // tracks if selected spending is multi-year
+    isMultiYear: false, // tracks if selected spending is multi-year
+    isSavings: false    // tracks if selected item is a savings (vs spending)
   },
 
   // Initialize the app
@@ -189,8 +190,9 @@ const app = {
     const actualAmount = billions * 1_000_000_000;
     this.state.spendingAmount = actualAmount;
 
-    // Manual input is not multi-year
+    // Manual input is not multi-year and not savings
     this.state.isMultiYear = false;
+    this.state.isSavings = false;
     document.getElementById('multiYearNote').style.display = 'none';
 
     // Update the hint to show the full dollar amount
@@ -209,9 +211,10 @@ const app = {
   },
 
   // Set spending from chip (optionally auto-select category for notable items)
-  setSpending(amount, category = null, multiYear = false) {
+  setSpending(amount, category = null, multiYear = false, isSavings = false) {
     this.state.spendingAmount = amount;
     this.state.isMultiYear = multiYear;
+    this.state.isSavings = isSavings;
 
     // Show/hide multi-year note
     const multiYearNote = document.getElementById('multiYearNote');
@@ -247,17 +250,18 @@ const app = {
     EXAMPLE_AMOUNTS.forEach((item, index) => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'chip';
+      btn.className = item.isSavings ? 'chip savings' : 'chip';
       btn.dataset.index = index;
       btn.dataset.value = item.value;
+      btn.dataset.savings = item.isSavings ? 'true' : 'false';
       btn.textContent = item.label;
-      btn.onclick = () => this.selectChip(index, item.value, item.category || null, item.multiYear || false);
+      btn.onclick = () => this.selectChip(index, item.value, item.category || null, item.multiYear || false, item.isSavings || false);
       container.appendChild(btn);
     });
   },
 
   // Select a chip and highlight it
-  selectChip(index, amount, category, multiYear = false) {
+  selectChip(index, amount, category, multiYear = false, isSavings = false) {
     // Update visual selection
     document.querySelectorAll('#spendingChips .chip').forEach(chip => {
       chip.classList.toggle('selected', chip.dataset.index === String(index));
@@ -265,7 +269,7 @@ const app = {
     this.state.selectedChipIndex = index;
 
     // Set the spending amount
-    this.setSpending(amount, category, multiYear);
+    this.setSpending(amount, category, multiYear, isSavings);
   },
 
   // Clear chip selection (when user types custom value)
@@ -298,9 +302,13 @@ const app = {
       category: this.state.category
     });
 
-    // Update result display
+    // Update result display - different text for savings vs spending
     document.getElementById('resultSpendingAmount').textContent = formatLargeNumber(this.state.spendingAmount);
-    document.getElementById('resultCategory').textContent = result.category.toLowerCase();
+    if (this.state.isSavings) {
+      document.getElementById('resultCategory').textContent = 'claimed savings';
+    } else {
+      document.getElementById('resultCategory').textContent = result.category.toLowerCase();
+    }
     document.getElementById('resultShare').textContent = formatCurrency(result.yourShare);
 
     // Get comparison
@@ -380,7 +388,8 @@ const app = {
       directTax: null,
       spendingAmount: 0,
       category: null,
-      isMultiYear: false
+      isMultiYear: false,
+      isSavings: false
     };
 
     // Reset UI

--- a/js/data.js
+++ b/js/data.js
@@ -158,7 +158,8 @@ const TRENDING_SPENDING = {
     source: 'DOGE official claims',
     lastVerified: '2025-01-10',
     category: 'general',
-    notes: 'Claimed cost savings from Department of Government Efficiency - accuracy disputed'
+    notes: 'Claimed cost savings from Department of Government Efficiency - accuracy disputed',
+    isSavings: true                  // This is a savings amount, not spending
   },
   trending2: {
     label: 'F-35 Program (Annual)',
@@ -223,11 +224,11 @@ const EXAMPLE_AMOUNTS = [
   { label: PERMANENT_SPENDING.jamesWebbTelescope.label, value: PERMANENT_SPENDING.jamesWebbTelescope.value, category: PERMANENT_SPENDING.jamesWebbTelescope.category, multiYear: PERMANENT_SPENDING.jamesWebbTelescope.multiYear },
   { label: PERMANENT_SPENDING.geraldRFordCarrier.label, value: PERMANENT_SPENDING.geraldRFordCarrier.value, category: PERMANENT_SPENDING.geraldRFordCarrier.category, multiYear: PERMANENT_SPENDING.geraldRFordCarrier.multiYear },
   // Trending spending items - rotated weekly based on news
-  { label: TRENDING_SPENDING.trending1.label, value: TRENDING_SPENDING.trending1.value, category: TRENDING_SPENDING.trending1.category, multiYear: TRENDING_SPENDING.trending1.multiYear },
-  { label: TRENDING_SPENDING.trending2.label, value: TRENDING_SPENDING.trending2.value, category: TRENDING_SPENDING.trending2.category, multiYear: TRENDING_SPENDING.trending2.multiYear },
-  { label: TRENDING_SPENDING.trending3.label, value: TRENDING_SPENDING.trending3.value, category: TRENDING_SPENDING.trending3.category, multiYear: TRENDING_SPENDING.trending3.multiYear },
-  { label: TRENDING_SPENDING.trending4.label, value: TRENDING_SPENDING.trending4.value, category: TRENDING_SPENDING.trending4.category, multiYear: TRENDING_SPENDING.trending4.multiYear },
-  { label: TRENDING_SPENDING.trending5.label, value: TRENDING_SPENDING.trending5.value, category: TRENDING_SPENDING.trending5.category, multiYear: TRENDING_SPENDING.trending5.multiYear },
-  { label: TRENDING_SPENDING.trending6.label, value: TRENDING_SPENDING.trending6.value, category: TRENDING_SPENDING.trending6.category, multiYear: TRENDING_SPENDING.trending6.multiYear },
-  { label: TRENDING_SPENDING.trending7.label, value: TRENDING_SPENDING.trending7.value, category: TRENDING_SPENDING.trending7.category, multiYear: TRENDING_SPENDING.trending7.multiYear }
+  { label: TRENDING_SPENDING.trending1.label, value: TRENDING_SPENDING.trending1.value, category: TRENDING_SPENDING.trending1.category, multiYear: TRENDING_SPENDING.trending1.multiYear, isSavings: TRENDING_SPENDING.trending1.isSavings },
+  { label: TRENDING_SPENDING.trending2.label, value: TRENDING_SPENDING.trending2.value, category: TRENDING_SPENDING.trending2.category, multiYear: TRENDING_SPENDING.trending2.multiYear, isSavings: TRENDING_SPENDING.trending2.isSavings },
+  { label: TRENDING_SPENDING.trending3.label, value: TRENDING_SPENDING.trending3.value, category: TRENDING_SPENDING.trending3.category, multiYear: TRENDING_SPENDING.trending3.multiYear, isSavings: TRENDING_SPENDING.trending3.isSavings },
+  { label: TRENDING_SPENDING.trending4.label, value: TRENDING_SPENDING.trending4.value, category: TRENDING_SPENDING.trending4.category, multiYear: TRENDING_SPENDING.trending4.multiYear, isSavings: TRENDING_SPENDING.trending4.isSavings },
+  { label: TRENDING_SPENDING.trending5.label, value: TRENDING_SPENDING.trending5.value, category: TRENDING_SPENDING.trending5.category, multiYear: TRENDING_SPENDING.trending5.multiYear, isSavings: TRENDING_SPENDING.trending5.isSavings },
+  { label: TRENDING_SPENDING.trending6.label, value: TRENDING_SPENDING.trending6.value, category: TRENDING_SPENDING.trending6.category, multiYear: TRENDING_SPENDING.trending6.multiYear, isSavings: TRENDING_SPENDING.trending6.isSavings },
+  { label: TRENDING_SPENDING.trending7.label, value: TRENDING_SPENDING.trending7.value, category: TRENDING_SPENDING.trending7.category, multiYear: TRENDING_SPENDING.trending7.multiYear, isSavings: TRENDING_SPENDING.trending7.isSavings }
 ];


### PR DESCRIPTION
## Summary

- Adds `isSavings: true` flag support for spending items that represent savings/reductions rather than spending
- Savings chips are styled with green color to visually distinguish them from regular spending items
- Result display shows "claimed savings" instead of the category name when a savings item is selected
- Updated weekly trending job instructions to guide Claude on when and how to use the isSavings flag

## Changes

| File | Change |
|------|--------|
| `js/data.js` | Added `isSavings: true` to DOGE Claimed Savings item, updated EXAMPLE_AMOUNTS to propagate flag |
| `js/app.js` | Added `isSavings` state tracking, updated chip rendering and result display |
| `css/styles.css` | Added `.chip.savings` styles with green color theme |
| `.github/workflows/weekly-trending-spending.yml` | Updated instructions to explain isSavings flag usage |

## Test plan

- [ ] Verify DOGE Claimed Savings chip appears green
- [ ] Click DOGE chip and verify result shows "claimed savings" instead of "general government"
- [ ] Verify regular spending chips (like F-35 Program) still show in blue
- [ ] Verify typing a custom amount doesn't show savings styling
- [ ] Verify Start Over resets the savings state

🤖 Generated with [Claude Code](https://claude.com/claude-code)