### PR TITLE
Make Your Personal Share section green for savings items

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -326,6 +326,14 @@ header p {
   margin-bottom: 1.5rem;
 }
 
+.result-card.savings {
+  background: linear-gradient(135deg, rgba(5, 150, 105, 0.05), rgba(5, 150, 105, 0.1));
+}
+
+.result-card.savings .result-amount {
+  color: var(--color-success);
+}
+
 .result-label {
   font-size: 0.9rem;
   color: var(--color-text-muted);

--- a/js/app.js
+++ b/js/app.js
@@ -316,6 +316,14 @@ const app = {
       category: this.state.category
     });
 
+    // Update result card styling - green for savings, blue for spending
+    const resultCard = document.querySelector('.result-card');
+    if (this.state.isSavings) {
+      resultCard.classList.add('savings');
+    } else {
+      resultCard.classList.remove('savings');
+    }
+
     // Update result display - different text for savings vs spending
     document.getElementById('resultSpendingAmount').textContent = formatLargeNumber(this.state.spendingAmount);
     if (this.state.isSavings) {


### PR DESCRIPTION
## Summary

- Makes the "Your Personal Share" result card display with green styling when showing savings items
- Matches the green chip styling introduced in PR #22 for visual consistency
- Green gradient background and green amount text for savings, blue for regular spending

## Changes

| File | Change |
|------|--------|
| `js/app.js` | Add/remove 'savings' class to result card based on `isSavings` state |
| `css/styles.css` | Add `.result-card.savings` styles with green color theme |

## Test plan

- [ ] Click DOGE Claimed Savings chip and verify the result card shows with green background and green amount
- [ ] Click a regular spending chip (like F-35 Program) and verify the result card shows with blue background and blue amount
- [ ] Switch between savings and regular spending items and verify colors update correctly
- [ ] Verify "Try Another Amount" button properly resets the styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)