### PR TITLE
Clear category selection when user enters custom spending amount

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -222,6 +222,10 @@ const app = {
 
     // Clear chip selection when user types custom value
     this.clearChipSelection();
+
+    // Clear category selection since manual input shouldn't inherit category from chips
+    this.state.category = null;
+    document.querySelectorAll('.category-btn').forEach(btn => btn.classList.remove('selected'));
   },
 
   // Set spending from chip (optionally auto-select category for notable items)


### PR DESCRIPTION
## Summary
- Fixes bug where "Where did it come from" category remained selected when switching from chip to manual input
- Clears category state and deselects category buttons when user types in the manual spending input field
- Prevents misleading "Your Personal Share" results from mismatched category/amount combinations

## Test plan
- [ ] Select a spending chip (e.g., "Ukraine Aid") and verify the category is auto-selected
- [ ] Enter a custom amount in the manual input field
- [ ] Verify the category selection is cleared (no button should be highlighted)
- [ ] Click Continue and verify you must manually select a category before seeing results

🤖 Generated with [Claude Code](https://claude.com/claude-code)