### PR TITLE
Fix savings chip appearing selected when unselected

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -254,19 +254,23 @@ header p {
 }
 
 .chip.savings {
-  background: rgba(5, 150, 105, 0.1);
-  border-color: var(--color-success);
-  color: var(--color-success);
+  background: var(--color-bg);
+  border-color: var(--color-border);
+  border-style: dashed;
+  color: inherit;
 }
 
 .chip.savings:hover {
-  background: rgba(5, 150, 105, 0.15);
+  background: rgba(5, 150, 105, 0.1);
   border-color: var(--color-success);
+  border-style: solid;
+  color: var(--color-success);
 }
 
 .chip.savings.selected {
-  background: rgba(5, 150, 105, 0.2);
+  background: rgba(5, 150, 105, 0.15);
   border-color: var(--color-success);
+  border-style: solid;
   color: var(--color-success);
 }
 


### PR DESCRIPTION
## Summary
- Fixed visual bug where savings chips (like "DOGE Claimed Savings") appeared selected even when they weren't
- Unselected savings chips now have neutral styling with a dashed border (to indicate they're savings items)
- Green highlighting only appears on hover and when the chip is actually selected

## Problem
When a user selected a savings chip and then clicked a different chip, the savings chip would lose its `selected` CSS class but still appear visually highlighted due to its base styling having a green background and border.

## Test plan
- [x] Verified with Playwright that only one chip appears selected at a time
- [ ] Manual test: Click "DOGE Claimed Savings", then click "F-35 Program" - only F-35 should look selected
- [ ] Verify savings chips have a subtle dashed border when unselected
- [ ] Verify savings chips turn green on hover and when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)