### PR TITLE
Use prebuilt devcontainer for CI jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  # Note: must be lowercase for Docker compatibility
+  DEVCONTAINER_IMAGE: ghcr.io/nickborgers/how-much-did-it-cost-me-devcontainer
+
 jobs:
-  claude:
+  # Build and cache devcontainer image
+  build-devcontainer:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -20,20 +25,169 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: always
+
+  # Respond to @claude mentions in comments
+  claude:
+    needs: build-devcontainer
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
+      packages: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
+      - name: Create gh config directory for devcontainer mount
+        run: mkdir -p ~/.config/gh
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--dangerously-skip-permissions"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine context and prompt
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Determine the user request based on event type
+          if [ "$EVENT_NAME" == "issue_comment" ] || [ "$EVENT_NAME" == "pull_request_review_comment" ]; then
+            echo "REQUEST<<EOF" >> $GITHUB_OUTPUT
+            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "context_type=comment" >> $GITHUB_OUTPUT
+          elif [ "$EVENT_NAME" == "pull_request_review" ]; then
+            echo "REQUEST<<EOF" >> $GITHUB_OUTPUT
+            echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "context_type=review" >> $GITHUB_OUTPUT
+          elif [ "$EVENT_NAME" == "issues" ]; then
+            echo "REQUEST<<EOF" >> $GITHUB_OUTPUT
+            echo "Issue Title: $ISSUE_TITLE" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "$ISSUE_BODY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "context_type=issue" >> $GITHUB_OUTPUT
+          fi
+
+          # Set the PR or issue number for responses
+          if [ -n "$PR_NUMBER" ]; then
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          elif [ -n "$ISSUE_NUMBER" ]; then
+            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Write request to file
+        run: |
+          cat > user_request.txt << 'EOF'
+          ${{ steps.context.outputs.REQUEST }}
+          EOF
+
+      - name: Run Claude Code in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            CONTEXT_TYPE=${{ steps.context.outputs.context_type }}
+            CONTEXT_NUMBER=${{ steps.context.outputs.number }}
+            REPO=${{ github.repository }}
+          runCmd: |
+            USER_REQUEST=$(cat user_request.txt)
+
+            claude --print \
+              --verbose \
+              --output-format stream-json \
+              --model opus \
+              --dangerously-skip-permissions \
+              --max-turns 400 \
+              "You are Claude, an AI assistant helping with the ${REPO} repository.
+
+            A user has tagged you in a GitHub ${CONTEXT_TYPE}. Here is their request:
+
+            ---
+            ${USER_REQUEST}
+            ---
+
+            ## Your Task
+
+            Analyze the request and help the user. You have full access to:
+            - Read and modify files in the repository
+            - Run bash commands and tests
+            - Use the gh CLI to interact with GitHub (comment on issues/PRs, create branches, etc.)
+            - Use Playwright via the playwright-skill for browser automation testing
+
+            ## Guidelines
+
+            1. If this is a code change request:
+               - Make the requested changes
+               - Test your changes if applicable
+               - Commit and push to the appropriate branch
+               - Comment on the issue/PR with a summary of what you did
+
+            2. If this is a question:
+               - Research the codebase to find the answer
+               - Respond with a clear, helpful answer via gh CLI
+
+            3. If this is a bug report or issue:
+               - Investigate the issue
+               - If you can fix it, create a branch, fix it, and open a PR
+               - Comment with your findings
+
+            ## Responding
+
+            Use the gh CLI to respond. Examples:
+            - For issues: gh issue comment ${CONTEXT_NUMBER} --body 'Your response'
+            - For PRs: gh pr comment ${CONTEXT_NUMBER} --body 'Your response'
+
+            Start by understanding the request and taking appropriate action." < /dev/null 2>&1 | tee ./claude-output.jsonl
+
+      - name: Upload Claude output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: claude-output
+          path: claude-output.jsonl
+          retention-days: 7

--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -15,8 +15,41 @@ permissions:
   pull-requests: write
   issues: read
   id-token: write
+  packages: write
+
+env:
+  # Note: must be lowercase for Docker compatibility
+  DEVCONTAINER_IMAGE: ghcr.io/nickborgers/how-much-did-it-cost-me-devcontainer
 
 jobs:
+  # Job: Build and cache devcontainer image
+  # This saves time in subsequent jobs by reusing the prebuilt image
+  build-devcontainer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.head_ref || github.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: always
+
   # Job 0: Check if PR author is authorized to trigger Claude reviews
   # This prevents arbitrary users from submitting PRs that could trick Claude
   # into visiting malicious URLs or executing harmful actions
@@ -54,10 +87,15 @@ jobs:
 
   # Job 1: Run unit tests for calculation logic
   # This ensures core calculation functions are correct before any other checks
+  # Uses devcontainer with Node.js pre-installed
   run-unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: build-devcontainer
     if: github.event.pull_request.draft != true
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -65,24 +103,34 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.head_ref || github.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          node-version: '22'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run unit tests
-        run: npm test
+      - name: Run unit tests in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          runCmd: |
+            npm install
+            npm test
 
   # Job 2: Run Playwright tests automatically (no Claude)
   # This runs the test script and saves results as an artifact
-  # Note: This job runs for all PRs since it only tests against localhost
+  # Uses prebuilt devcontainer with Playwright already installed
   run-playwright-tests:
     name: Run Playwright Tests
     runs-on: ubuntu-latest
+    needs: build-devcontainer
     if: github.event.pull_request.draft != true
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -90,32 +138,32 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.head_ref || github.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          node-version: '22'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: |
-          npm install -g http-server
-          npm init -y
-          npm install playwright
-          npx playwright install chromium --with-deps
+      - name: Run Playwright tests in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            TEST_URL=http://localhost:8080
+            SCREENSHOTS_DIR=./test-results/screenshots
+            RESULTS_FILE=./test-results/results.json
+          runCmd: |
+            # Start local server in background
+            http-server . -p 8080 &
+            sleep 3
+            curl -s http://localhost:8080 > /dev/null || (echo "Server failed to start" && exit 1)
 
-      - name: Start local server
-        run: |
-          http-server . -p 8080 &
-          sleep 3
-          curl -s http://localhost:8080 > /dev/null || (echo "Server failed to start" && exit 1)
-
-      - name: Run Playwright tests
-        run: |
-          mkdir -p test-results
-          node tests/impatient-user-test.js
-        env:
-          TEST_URL: http://localhost:8080
-          SCREENSHOTS_DIR: ./test-results/screenshots
-          RESULTS_FILE: ./test-results/results.json
+            # Run Playwright tests
+            mkdir -p test-results
+            node tests/impatient-user-test.js
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -125,15 +173,21 @@ jobs:
           path: test-results/
           retention-days: 7
 
-  # Job 2: Claude reviews the Playwright test results and posts a comment
+  # Job 3: Claude reviews the Playwright test results and posts a comment
+  # Uses prebuilt devcontainer with Claude CLI already installed
   impatient-user-review:
     name: Impatient User Review
     runs-on: ubuntu-latest
-    needs: [check-author-authorization, run-playwright-tests]
+    needs: [check-author-authorization, build-devcontainer, run-playwright-tests]
     if: |
       always() &&
       github.event.pull_request.draft != true &&
-      needs.check-author-authorization.outputs.authorized == 'true'
+      needs.check-author-authorization.outputs.authorized == 'true' &&
+      needs.build-devcontainer.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -147,17 +201,33 @@ jobs:
           name: playwright-test-results
           path: test-results/
 
-      - name: Review test results
-        uses: anthropics/claude-code-action@v1
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+      - name: Create gh config directory for devcontainer mount
+        run: mkdir -p ~/.config/gh
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.WORKFLOW_PAT }}
-          claude_args: "--dangerously-skip-permissions"
-          prompt: |
-            You are reviewing automated Playwright test results for the "How Much Did It Cost Me?" web application.
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Review test results with Claude
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          runCmd: |
+            claude --print \
+              --output-format stream-json \
+              --model sonnet \
+              --dangerously-skip-permissions \
+              --max-turns 50 \
+              "You are reviewing automated Playwright test results for the 'How Much Did It Cost Me?' web application.
 
             The test results are in test-results/results.json. Read this file to understand what happened.
             Screenshots from the test are in test-results/screenshots/.
@@ -182,32 +252,46 @@ jobs:
             [Summary of second visit test - was income remembered? Did the welcome banner appear?]
 
             ### Issues Found
-            [List any issues, or "None" if all tests passed]
+            [List any issues, or 'None' if all tests passed]
 
             ## CRITICAL: Post Your Review
 
-            After analyzing the results, you MUST post your review as a comment on PR #${{ github.event.pull_request.number }} using:
-            ```
-            gh pr comment ${{ github.event.pull_request.number }} --body "YOUR_REVIEW_HERE"
-            ```
+            After analyzing the results, you MUST post your review as a comment on PR #${PR_NUMBER} using:
+            \`\`\`
+            gh pr comment ${PR_NUMBER} --body 'YOUR_REVIEW_HERE'
+            \`\`\`
 
             Use a heredoc for multi-line comments:
-            ```
-            gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
+            \`\`\`
+            gh pr comment ${PR_NUMBER} --body \"\$(cat <<'EOF'
             ## Impatient User Review
             ...your review content...
             EOF
-            )"
-            ```
+            )\"
+            \`\`\`" < /dev/null 2>&1 | tee ./impatient-review-output.jsonl
 
-  # Job 3: Accuracy review - checks if any numbers in the PR are accurate
+      - name: Upload review output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: impatient-review-output
+          path: impatient-review-output.jsonl
+          retention-days: 7
+
+  # Job 4: Accuracy review - checks if any numbers in the PR are accurate
+  # Uses prebuilt devcontainer with Claude CLI already installed
   accuracy-review:
     name: Data Accuracy Review
     runs-on: ubuntu-latest
-    needs: check-author-authorization
+    needs: [check-author-authorization, build-devcontainer]
     if: |
       github.event.pull_request.draft != true &&
-      needs.check-author-authorization.outputs.authorized == 'true'
+      needs.check-author-authorization.outputs.authorized == 'true' &&
+      needs.build-devcontainer.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -230,18 +314,36 @@ jobs:
             echo "data_changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Review data accuracy
+      - name: Create gh config directory for devcontainer mount
         if: steps.changed-files.outputs.data_changed == 'true'
-        uses: anthropics/claude-code-action@v1
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: mkdir -p ~/.config/gh
+
+      - name: Log in to GHCR
+        if: steps.changed-files.outputs.data_changed == 'true'
+        uses: docker/login-action@v3
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.WORKFLOW_PAT }}
-          claude_args: "--dangerously-skip-permissions"
-          prompt: |
-            You are a data accuracy reviewer for the "How Much Did It Cost Me?" application.
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Review data accuracy with Claude
+        if: steps.changed-files.outputs.data_changed == 'true'
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          runCmd: |
+            claude --print \
+              --output-format stream-json \
+              --model sonnet \
+              --dangerously-skip-permissions \
+              --max-turns 100 \
+              "You are a data accuracy reviewer for the 'How Much Did It Cost Me?' application.
 
             This PR modifies js/data.js which contains critical financial data:
             - Federal income tax brackets and rates
@@ -294,29 +396,43 @@ jobs:
 
             ## CRITICAL: Post Your Review
 
-            After completing your analysis, you MUST post your review as a comment on PR #${{ github.event.pull_request.number }} using:
-            ```
-            gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
+            After completing your analysis, you MUST post your review as a comment on PR #${PR_NUMBER} using:
+            \`\`\`
+            gh pr comment ${PR_NUMBER} --body \"\$(cat <<'EOF'
             ## Data Accuracy Review
             ...your review content...
             EOF
-            )"
-            ```
+            )\"
+            \`\`\`" < /dev/null 2>&1 | tee ./accuracy-review-output.jsonl
+
+      - name: Upload review output
+        uses: actions/upload-artifact@v4
+        if: steps.changed-files.outputs.data_changed == 'true'
+        with:
+          name: accuracy-review-output
+          path: accuracy-review-output.jsonl
+          retention-days: 7
 
       - name: Skip if no data changes
         if: steps.changed-files.outputs.data_changed != 'true'
         run: |
           echo "No changes to js/data.js - skipping accuracy review"
 
-  # Job 4: Execute test plan from PR description
+  # Job 5: Execute test plan from PR description
   # If the PR has a "Test plan" section, Claude will execute those steps with Playwright
+  # Uses prebuilt devcontainer with Claude CLI and Playwright already installed
   test-plan-executor:
     name: Test Plan Executor
     runs-on: ubuntu-latest
-    needs: check-author-authorization
+    needs: [check-author-authorization, build-devcontainer]
     if: |
       github.event.pull_request.draft != true &&
-      needs.check-author-authorization.outputs.authorized == 'true'
+      needs.check-author-authorization.outputs.authorized == 'true' &&
+      needs.build-devcontainer.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -352,39 +468,52 @@ jobs:
             echo "No test plan section found in PR description"
           fi
 
-      - name: Setup Node.js
+      - name: Create gh config directory for devcontainer mount
         if: steps.extract-test-plan.outputs.has_test_plan == 'true'
-        uses: actions/setup-node@v4
+        run: mkdir -p ~/.config/gh
+
+      - name: Log in to GHCR
+        if: steps.extract-test-plan.outputs.has_test_plan == 'true'
+        uses: docker/login-action@v3
         with:
-          node-version: '22'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Write PR body to file for devcontainer
         if: steps.extract-test-plan.outputs.has_test_plan == 'true'
-        run: |
-          npm install -g http-server
-          npm init -y
-          npm install playwright
-          npx playwright install chromium --with-deps
-
-      - name: Start local server
-        if: steps.extract-test-plan.outputs.has_test_plan == 'true'
-        run: |
-          http-server . -p 8080 &
-          sleep 3
-          curl -s http://localhost:8080 > /dev/null || (echo "Server failed to start" && exit 1)
-
-      - name: Execute test plan
-        if: steps.extract-test-plan.outputs.has_test_plan == 'true'
-        uses: anthropics/claude-code-action@v1
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "$PR_BODY" > pr_body_for_claude.txt
+
+      - name: Execute test plan with Claude in devcontainer
+        if: steps.extract-test-plan.outputs.has_test_plan == 'true'
+        uses: devcontainers/ci@v0.3
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.WORKFLOW_PAT }}
-          claude_args: "--dangerously-skip-permissions"
-          prompt: |
-            You are a test executor. The PR author has provided a test plan that you need to execute.
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          runCmd: |
+            # Start local server in background
+            http-server . -p 8080 &
+            sleep 3
+            curl -s http://localhost:8080 > /dev/null || (echo "Server failed to start" && exit 1)
+
+            # Read PR body for the prompt
+            PR_BODY_CONTENT=$(cat pr_body_for_claude.txt)
+
+            # Run Claude to execute the test plan
+            claude --print \
+              --output-format stream-json \
+              --model sonnet \
+              --dangerously-skip-permissions \
+              --max-turns 200 \
+              "You are a test executor. The PR author has provided a test plan that you need to execute.
 
             The app is running at http://localhost:8080
 
@@ -392,11 +521,11 @@ jobs:
 
             The following test plan was specified by the PR author:
 
-            ```
-            ${{ github.event.pull_request.body }}
-            ```
+            \`\`\`
+            ${PR_BODY_CONTENT}
+            \`\`\`
 
-            Look for the "Test plan" section in the PR description above and execute each step.
+            Look for the 'Test plan' section in the PR description above and execute each step.
 
             ## Your Task
 
@@ -422,7 +551,7 @@ jobs:
             **Status**: [PASSED / FAILED / PARTIAL]
 
             ### Steps Executed
-            [For each step in the test plan, report: ✓ Passed or ✗ Failed with details]
+            [For each step in the test plan, report: Passed or Failed with details]
 
             ### Evidence
             [Reference screenshots taken during testing]
@@ -432,20 +561,28 @@ jobs:
 
             ## CRITICAL: Post Your Review
 
-            After executing the test plan, you MUST post your results as a comment on PR #${{ github.event.pull_request.number }} using:
-            ```
-            gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
+            After executing the test plan, you MUST post your results as a comment on PR #${PR_NUMBER} using:
+            \`\`\`
+            gh pr comment ${PR_NUMBER} --body \"\$(cat <<'EOF'
             ## Test Plan Execution
             ...your results...
             EOF
-            )"
-            ```
+            )\"
+            \`\`\`
 
             IMPORTANT:
             - Execute the EXACT steps specified in the test plan
             - Don't skip steps or make assumptions
             - If a step is unclear, note it but attempt to execute your best interpretation
-            - Report honestly if something fails
+            - Report honestly if something fails" < /dev/null 2>&1 | tee ./test-plan-output.jsonl
+
+      - name: Upload test plan output
+        uses: actions/upload-artifact@v4
+        if: steps.extract-test-plan.outputs.has_test_plan == 'true'
+        with:
+          name: test-plan-output
+          path: test-plan-output.jsonl
+          retention-days: 7
 
       - name: Skip if no test plan
         if: steps.extract-test-plan.outputs.has_test_plan != 'true'
@@ -456,13 +593,14 @@ jobs:
   all-agent-reviews-passed:
     name: All Agent Reviews
     runs-on: ubuntu-latest
-    needs: [check-author-authorization, run-unit-tests, run-playwright-tests, impatient-user-review, accuracy-review, test-plan-executor]
+    needs: [check-author-authorization, build-devcontainer, run-unit-tests, run-playwright-tests, impatient-user-review, accuracy-review, test-plan-executor]
     if: always()
     steps:
       - name: Check all reviews passed
         run: |
           echo "Checking results of all agent reviews..."
           echo "check-author-authorization: ${{ needs.check-author-authorization.result }}"
+          echo "build-devcontainer: ${{ needs.build-devcontainer.result }}"
           echo "run-unit-tests: ${{ needs.run-unit-tests.result }}"
           echo "run-playwright-tests: ${{ needs.run-playwright-tests.result }}"
           echo "impatient-user-review: ${{ needs.impatient-user-review.result }}"
@@ -472,6 +610,12 @@ jobs:
           # Authorization check must pass
           if [ "${{ needs.check-author-authorization.result }}" != "success" ]; then
             echo "FAILED: Author authorization check did not succeed"
+            exit 1
+          fi
+
+          # Devcontainer build must pass
+          if [ "${{ needs.build-devcontainer.result }}" != "success" ]; then
+            echo "FAILED: Devcontainer build did not succeed"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Migrate CI workflows to use a prebuilt devcontainer image from GHCR instead of installing packages in each job
- Reduces CI build time by reusing a cached container with Claude CLI and Playwright pre-installed
- Pattern matches the [home-automation repository](https://github.com/NickBorgers/home-automation/tree/main/.github/workflows) approach

## Changes

### pr-reviews.yml
- Added `build-devcontainer` job that builds/caches the devcontainer image to GHCR
- Updated `run-playwright-tests` to use the devcontainer (no more `npm install`, `npx playwright install`)
- Updated `impatient-user-review` to run Claude CLI inside devcontainer
- Updated `accuracy-review` to run Claude CLI inside devcontainer
- Updated `test-plan-executor` to run both Playwright and Claude CLI inside devcontainer
- Updated `all-agent-reviews-passed` gate to check devcontainer build

### claude.yml
- Added `build-devcontainer` job for consistency
- Converted from `anthropics/claude-code-action@v1` to devcontainer-based execution
- Claude now runs directly in the devcontainer with full access to pre-installed tools

## Benefits
- **Faster CI runs**: No more waiting for `npm install`, `npx playwright install chromium --with-deps`
- **Consistency**: All Claude-based jobs use the same devcontainer pattern as monthly-data-verification and weekly-trending-spending workflows
- **Pre-installed tools**: Claude CLI and Playwright are already in the container, ready to use

## Test plan
- [ ] Verify the PR triggers the workflow and the devcontainer builds successfully
- [ ] Verify the Playwright tests run inside the devcontainer
- [ ] Verify Claude-based reviews execute correctly
- [ ] Confirm build time is reduced compared to previous package installation approach

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)