### PR TITLE
Display proportion as friendly "1 in X" format instead of scientific notation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -358,7 +358,7 @@ const app = {
     document.getElementById('mathYourTax').textContent = formatCurrency(result.breakdown.yourTax);
     document.getElementById('mathTaxType').textContent = result.breakdown.taxType;
     document.getElementById('mathTotalRevenue').textContent = formatLargeNumber(result.breakdown.totalRevenue || FEDERAL_BUDGET.revenue.individualIncomeTax);
-    document.getElementById('mathProportion').textContent = (result.breakdown.proportion * 100).toExponential(2) + '%';
+    document.getElementById('mathProportion').textContent = formatProportion(result.breakdown.proportion);
     document.getElementById('mathSpending').textContent = formatLargeNumber(this.state.spendingAmount);
     document.getElementById('mathShare').textContent = formatCurrency(result.yourShare);
 

--- a/js/calculations.js
+++ b/js/calculations.js
@@ -184,6 +184,28 @@ function formatLargeNumber(amount) {
 }
 
 /**
+ * Format a proportion in a user-friendly "1 in X" format
+ * @param {number} proportion - The proportion as a decimal (e.g., 0.0000000221)
+ * @returns {string} Formatted string like "1 in 45 million"
+ */
+function formatProportion(proportion) {
+  if (proportion <= 0) return '0';
+  if (proportion >= 1) return '100%';
+
+  const oneInX = Math.round(1 / proportion);
+
+  if (oneInX >= 1_000_000_000) {
+    return `1 in ${(oneInX / 1_000_000_000).toFixed(1)} billion`;
+  } else if (oneInX >= 1_000_000) {
+    return `1 in ${(oneInX / 1_000_000).toFixed(1)} million`;
+  } else if (oneInX >= 1_000) {
+    return `1 in ${(oneInX / 1_000).toFixed(1)} thousand`;
+  } else {
+    return `1 in ${oneInX.toLocaleString()}`;
+  }
+}
+
+/**
  * Parse a currency string to a number
  * @param {string} str - String like "$1,000,000" or "1000000"
  * @returns {number} Parsed number


### PR DESCRIPTION
## Summary
- Changes the "Your proportion" display from scientific notation (e.g., `2.21e-6%`) to an intuitive "1 in X" format (e.g., `1 in 45.2 million`)
- Adds `formatProportion()` function to handle the conversion with appropriate scale labels (thousand/million/billion)

## Before
```
Your proportion: 2.21e-6%
```

## After
```
Your proportion: 1 in 45.2 million
```

## Test plan
- [x] All existing unit tests pass
- [ ] Manual verification in browser that proportion displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)