### PR TITLE
Fix devcontainer mount failure in CI jobs

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -103,6 +103,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.head_ref || github.ref }}
 
+      - name: Create gh config directory for devcontainer mount
+        run: mkdir -p ~/.config/gh
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -137,6 +140,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || github.head_ref || github.ref }}
+
+      - name: Create gh config directory for devcontainer mount
+        run: mkdir -p ~/.config/gh
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Add missing `mkdir -p ~/.config/gh` step to `run-unit-tests` and `run-playwright-tests` jobs

## Problem

The devcontainer.json has a mount configuration:

```json
"mounts": [
  "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind"
]
```

This tries to bind `~/.config/gh` from the host into the container. On local development machines, this directory exists (from the `gh` CLI). On GitHub Actions runners, this directory doesn't exist by default, causing the devcontainer to fail with:

```
docker: Error response from daemon: invalid mount config for type "bind": 
bind source path does not exist: /home/runner/.config/gh
```

## Fix

Add `mkdir -p ~/.config/gh` before running the devcontainer in jobs that were missing it:
- `run-unit-tests`
- `run-playwright-tests`

Other jobs (`impatient-user-review`, `accuracy-review`, `test-plan-executor`) and other workflows already had this step.

## Impact

This fix will unblock PRs #32 and #33 which are currently failing due to this infrastructure issue.

## Test plan
- [x] Merge this PR first
- [ ] Re-run the CI on PRs #32 and #33 to verify they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)