### PR TITLE
Fix Playwright test ES module syntax

### DIFF
--- a/tests/impatient-user-test.js
+++ b/tests/impatient-user-test.js
@@ -2,9 +2,9 @@
 // This test simulates a user who wants to quickly check federal spending costs
 // and expects the app to remember their information for faster repeat visits
 
-const { chromium } = require('playwright');
-const fs = require('fs');
-const path = require('path');
+import { chromium } from 'playwright';
+import fs from 'fs';
+import path from 'path';
 
 const BASE_URL = process.env.TEST_URL || 'http://localhost:8080';
 const SCREENSHOTS_DIR = process.env.SCREENSHOTS_DIR || './test-screenshots';


### PR DESCRIPTION
## Summary
- Convert Playwright test from CommonJS to ES module syntax

## Problem

The `tests/impatient-user-test.js` file uses CommonJS `require()` syntax:
```js
const { chromium } = require('playwright');
const fs = require('fs');
const path = require('path');
```

But `package.json` has `"type": "module"`, which means all `.js` files are treated as ES modules. This causes:
```
ReferenceError: require is not defined in ES module scope
```

## Fix

Convert to ES module imports:
```js
import { chromium } from 'playwright';
import fs from 'fs';
import path from 'path';
```

## Impact

This fix will unblock PRs #32 and #33 which are failing the Playwright test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)