### PR TITLE
Add playwright dependency for Playwright tests

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -162,6 +162,9 @@ jobs:
             SCREENSHOTS_DIR=./test-results/screenshots
             RESULTS_FILE=./test-results/results.json
           runCmd: |
+            # Install dependencies
+            npm install
+
             # Start local server in background
             http-server . -p 8080 &
             sleep 3

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "playwright": "^1.40.0",
     "vitest": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add playwright to devDependencies
- Add `npm install` step before running Playwright tests in CI

## Problem

The `tests/impatient-user-test.js` imports playwright:
```js
import { chromium } from 'playwright';
```

But:
1. `playwright` was not in package.json dependencies
2. The workflow didn't run `npm install` before the test

This caused:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright'
```

## Fix

1. Added `playwright` to devDependencies
2. Added `npm install` step in the Playwright test job

## Impact

This fix will unblock PRs #32 and #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)