### PR TITLE
Fix missing --verbose flag for Claude agent reviews

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -232,6 +232,7 @@ jobs:
             PR_NUMBER=${{ github.event.pull_request.number }}
           runCmd: |
             claude --print \
+              --verbose \
               --output-format stream-json \
               --model sonnet \
               --dangerously-skip-permissions \
@@ -343,6 +344,7 @@ jobs:
             PR_NUMBER=${{ github.event.pull_request.number }}
           runCmd: |
             claude --print \
+              --verbose \
               --output-format stream-json \
               --model sonnet \
               --dangerously-skip-permissions \
@@ -507,6 +509,7 @@ jobs:
 
             # Run Claude to execute the test plan
             claude --print \
+              --verbose \
               --output-format stream-json \
               --model sonnet \
               --dangerously-skip-permissions \


### PR DESCRIPTION
## Summary
- Add missing `--verbose` flag to all claude commands in PR review jobs

## Problem

The Claude agent review jobs (Impatient User Review, Data Accuracy Review, Test Plan Executor) were failing silently with:
```
Error: When using --print, --output-format=stream-json requires --verbose
```

This prevented the agents from posting review comments to PRs.

## Fix

Add `--verbose` flag to all three claude commands in the workflow, matching what `claude.yml` already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)