### PR TITLE
Fix scheduled workflows to properly create PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -130,11 +130,18 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             CONTEXT_TYPE=${{ steps.context.outputs.context_type }}
             CONTEXT_NUMBER=${{ steps.context.outputs.number }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Configure git identity for commits
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+
+            # Authenticate gh CLI with the GitHub token
+            echo "$GH_TOKEN" | gh auth login --with-token
+
             USER_REQUEST=$(cat user_request.txt)
 
             claude --print \

--- a/.github/workflows/monthly-data-verification.yml
+++ b/.github/workflows/monthly-data-verification.yml
@@ -76,10 +76,17 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             REPO=${{ github.repository }}
             RUN_DATE=${{ github.event.schedule && 'scheduled' || 'manual' }}
           runCmd: |
+            # Configure git identity for commits
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+
+            # Authenticate gh CLI with the GitHub token
+            echo "$GH_TOKEN" | gh auth login --with-token
+
             # Run Claude Code to verify data accuracy
             # Claude has web search capabilities to verify information
             claude --print \
@@ -184,6 +191,7 @@ jobs:
             - Include confidence levels - if you're uncertain about a finding, note it
             - Prefer authoritative sources (official docs, pricing pages) over third-party sites
             - If a data point cannot be verified (no reliable source found), note this but don't change it
+            - NEVER modify files in .github/workflows/ - the GITHUB_TOKEN cannot push workflow changes
 
             Start by exploring the repository structure to understand what data exists." < /dev/null 2>&1 | tee ./verification-output.jsonl
 

--- a/.github/workflows/weekly-trending-spending.yml
+++ b/.github/workflows/weekly-trending-spending.yml
@@ -76,9 +76,16 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Configure git identity for commits
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+
+            # Authenticate gh CLI with the GitHub token
+            echo "$GH_TOKEN" | gh auth login --with-token
+
             # Run Claude Code to find trending federal spending topics
             claude --print \
               --verbose \


### PR DESCRIPTION
## Summary
- Fix git identity configuration before Claude runs to avoid "Author identity unknown" errors
- Authenticate gh CLI before Claude runs to enable PR creation and comments
- Switch all Claude workflows to use `WORKFLOW_PAT` instead of `GITHUB_TOKEN` (consistent with pr-reviews.yml)
- Add instruction to monthly verification to never modify workflow files

## Workflows Fixed
- `weekly-trending-spending.yml` - scheduled weekly updates
- `monthly-data-verification.yml` - scheduled monthly verification
- `claude.yml` - @claude mention handler

## Changes
1. **Git identity config** - Added before Claude runs in all three workflows
2. **gh CLI authentication** - Added `gh auth login --with-token` before Claude runs
3. **WORKFLOW_PAT** - Switched from `GITHUB_TOKEN` to `WORKFLOW_PAT` for Claude's `GH_TOKEN` (matches pr-reviews.yml pattern)
4. **Workflow file restriction** - Monthly verification now instructed to never modify `.github/workflows/` files

## Test plan
- [ ] Manually trigger weekly trending spending workflow and verify PR is created
- [ ] Manually trigger monthly data verification workflow and verify it completes without push errors
- [ ] Tag @claude in an issue to verify git commits work

## Root Cause Analysis

### Why WORKFLOW_PAT?
- `GITHUB_TOKEN` cannot trigger other workflows (by design)
- `GITHUB_TOKEN` has limited permissions for PR operations in some cases
- `pr-reviews.yml` already uses `WORKFLOW_PAT` for Claude's gh CLI operations
- Using consistent token across all Claude workflows simplifies debugging

### Issues Found
| Workflow | Issue | Fix |
|----------|-------|-----|
| Weekly Trending | Branch pushed but PR creation failed | WORKFLOW_PAT + gh auth |
| Monthly Verification | Push failed on workflow file changes | Instruction not to modify workflows |
| Claude (@mentions) | Would fail on commits | Git config + WORKFLOW_PAT |

🤖 Generated with [Claude Code](https://claude.com/claude-code)