### PR TITLE
Reduce topic bias in weekly trending spending workflow

### DIFF
--- a/.github/workflows/weekly-trending-spending.yml
+++ b/.github/workflows/weekly-trending-spending.yml
@@ -98,23 +98,26 @@ jobs:
 
             YOUR TASK:
 
-            1. **SEARCH FOR TRENDING SPENDING**: Use web search to find the TOP 7 most talked-about
-               federal spending topics RIGHT NOW. Look for:
-               - Government spending scandals or controversies
-               - Budget debates currently in Congress
-               - Wasteful spending reports or investigations
-               - DOGE (Department of Government Efficiency) claims and activities
-               - Military spending controversies
-               - Social program debates (SNAP, Medicare, etc.)
-               - Infrastructure or project cost overruns
-               - Any federal spending making headlines this week
+            1. **SEARCH FOR TRENDING SPENDING**: Use web search to find the TOP 7 most
+               controversial, scandalous, or debated federal spending items RIGHT NOW.
+
+               Look for spending that is:
+               - Currently generating controversy or debate (within the last 1-2 weeks)
+               - Being criticized as wasteful, excessive, or inappropriate
+               - Subject to investigations or scandals
+               - Generating strong reactions across the political spectrum
+               - Making headlines for the wrong reasons
+
+               Examples might include government efficiency debates, program cost overruns,
+               controversial allocations, spending scandals, or budget battles - but don't
+               limit yourself to these categories. Find whatever is actually controversial.
 
                Search queries to try:
                - 'federal spending controversy this week'
-               - 'government waste scandal news'
-               - 'DOGE government spending news'
-               - 'budget debate Congress billions'
-               - 'federal program cost overrun news'
+               - 'government spending scandal news'
+               - 'wasteful spending news'
+               - 'budget debate Congress controversy'
+               - 'federal spending criticism news'
 
             2. **SELECT THE TOP 7**: Choose items that are:
                - Currently in the news (within the last week or two)


### PR DESCRIPTION
## Summary

- Removes specific topic anchoring (DOGE, military spending, social programs) from the weekly trending spending workflow
- Maintains the focus on controversial/scandalous spending while reducing bias toward specific categories
- Updates search queries to be more generic while still targeting controversial topics

## Problem

The previous prompt listed specific topic categories (DOGE, military controversies, social program debates, etc.) which could cause the LLM to:
- Always try to find items in those specific categories even when they're not the most controversial that week
- Force category diversity rather than picking the 7 most controversial items regardless of type
- Miss controversies that don't fit the pre-defined buckets

## Solution

Replace the prescriptive topic list with open-ended guidance that:
- Describes what makes spending controversial (criticized as wasteful, under investigation, generating strong reactions, etc.)
- Provides examples as inspiration without requiring them
- Explicitly states "don't limit yourself to these categories"
- Keeps search queries focused on controversy/scandal/waste but removes specific topic names

The workflow still finds controversial spending (as intended), but now discovers it organically rather than being steered toward predetermined categories.

## Test plan

- Wait for next Monday's scheduled run
- Verify the agent finds controversial items without forcing specific categories
- Check that results still align with the goal of surfacing debated/scandalous spending

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)