### PR TITLE
Data Update: Monthly Accuracy Verification - July 2026

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -133,7 +133,7 @@ const PERMANENT_SPENDING = {
     value: 13_300_000_000,           // $13.3 billion (USS Gerald R. Ford total program cost)
     source: 'Congressional Research Service',
     sourceUrl: 'https://crsreports.congress.gov/product/pdf/RS/RS20643',
-    lastVerified: DATA_LAST_UPDATED,
+    lastVerified: '2026-07-01',
     category: 'defense',
     notes: 'Total acquisition cost for lead ship CVN-78',
     multiYear: true                  // Spent over construction period, not in one year
@@ -142,8 +142,8 @@ const PERMANENT_SPENDING = {
     label: 'James Webb Space Telescope',
     value: 10_000_000_000,           // $10 billion (total development cost)
     source: 'NASA',
-    sourceUrl: 'https://www.nasa.gov/mission_pages/webb/about/index.html',
-    lastVerified: DATA_LAST_UPDATED,
+    sourceUrl: 'https://science.nasa.gov/mission/webb/about-overview',
+    lastVerified: '2026-07-01',
     category: 'general',
     notes: 'Total lifecycle development cost',
     multiYear: true                  // Spent over development period, not in one year


### PR DESCRIPTION
## Monthly Data Accuracy Verification

Automated monthly verification of the `PERMANENT_SPENDING` items in `js/data.js`. Both dollar figures were confirmed accurate against authoritative sources; the only correction is a stale NASA source URL.

### Summary of Changes
- `js/data.js` — Updated the James Webb Space Telescope source URL to its current canonical location and refreshed `lastVerified` dates on both permanent spending items.

### Verification Details

**1. Gerald R. Ford Aircraft Carrier (CVN-78) — $13.3B — ✅ Accurate, no change**
- **Verified value**: $13.3 billion total acquisition cost matches the CRS figure of $13,316.5M (then-year dollars) final procurement cost for the lead ship.
- **Source**: Congressional Research Service, Navy Ford (CVN-78) Class Aircraft Carrier Program (RS20643) — https://www.congress.gov/crs-product/RS20643
- **Confidence**: High

**2. James Webb Space Telescope — $10B — ✅ Accurate, no change**
- **Verified value**: $10 billion total lifecycle/development cost. Total project spending eclipsed $10B through FY2021; the telescope launched (Dec 2021) at just under $10B.
- **Source**: NASA — https://science.nasa.gov/mission/webb/about-overview
- **Confidence**: High

**3. JWST source URL — ⚠️ Corrected**
- **What was incorrect**: `https://www.nasa.gov/mission_pages/webb/about/index.html`
- **What it should be**: `https://science.nasa.gov/mission/webb/about-overview`
- **Why**: The old URL returns a `301 Moved Permanently` redirect to the new canonical page after NASA's site restructure. Updated to the current live location (verified 200 OK).
- **Confidence**: High

### Notes
- The Ford carrier CRS URL (`crsreports.congress.gov/product/pdf/RS/RS20643`) returned 403 to the automated fetch (bot-blocking), but the CRS product was independently confirmed to exist and match the $13.3B figure, so it was left unchanged.
- `TRENDING_SPENDING` items were intentionally **not** verified — they are maintained by the separate weekly trending workflow.
- Core 2024 tax bracket / FICA / federal budget data was not re-verified this cycle (stable historical figures).

### Files Modified
- `js/data.js`

### Verification Date
2026-07-01

---
🤖 Generated by Monthly Data Accuracy Verification workflow